### PR TITLE
perf(task-queue): use faster checking for empty array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,18 +49,18 @@ export class TaskQueue {
   }
 
   queueMicroTask(task){
-    if (!this.microTaskQueue.length) {
+    if (this.microTaskQueue.length < 1) {
       this.requestFlushMicroTaskQueue();
     }
-    
+
     this.microTaskQueue.push(task);
   }
 
   queueTask(task){
-    if (!this.taskQueue.length) {
+    if (this.taskQueue.length < 1) {
       this.requestFlushTaskQueue();
     }
-    
+
     this.taskQueue.push(task);
   }
 


### PR DESCRIPTION
perf(task-queue): use faster checking for empty array

According to following JSPerf test:
http://jsperf.com/arr-length-vs-arr-length-0/3 the way how to check for
empty arrays has quite a difference based on browsers. Improvement for
Chrome vs IE
